### PR TITLE
Naming and Cross Withdraw

### DIFF
--- a/MinionFactory.sol
+++ b/MinionFactory.sol
@@ -1,8 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.7.5;
 
+interface IERC20 { // brief interface for moloch erc20 token txs
+    function balanceOf(address who) external view returns (uint256);
+    
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+    
+    function approve(address spender, uint256 amount) external returns (bool);
+}
+
 interface IMOLOCH { // brief interface for moloch dao v2
+
+
     function depositToken() external view returns (address);
+    
+    function tokenWhitelist(address token) external view returns (bool);
     
     function getProposalFlags(uint256 proposalId) external view returns (bool[6] memory);
 
@@ -38,6 +52,7 @@ contract Minion {
     event ExecuteAction(uint256 proposalId, address executor);
     event DoWithdraw(address token, uint256 amount);
     event CrossWithdraw(address target, address token, uint256 amount);
+    event PulledFunds(address moloch, uint256 amount);
 
     function init(address _moloch) external {
         require(!initialized, "initialized"); 
@@ -52,16 +67,16 @@ contract Minion {
     }
     
     function crossWithdraw(address target, address token, uint256 amount) external {
-
-        /* 
-        Target needs to have a withdrawBalance function that uses the same
-        name and inputs as the withdrawBalance in a Moloch -- so probably other Molochs. 
-        */ 
-        
+        // @Dev - Target needs to have a withdrawBalance functions
+        bool whitelisted = moloch.tokenWhitelist(token);
+        require(whitelisted, "not a whitelisted token");
         IMOLOCH(target).withdrawBalance(token, amount); 
+        
+        // Transfers token into DAO. 
+        IERC20(token).transfer(address(moloch), amount);
         emit CrossWithdraw(target, token, amount);
     }
-
+    
     function proposeAction(
         address actionTo,
         uint256 actionValue,
@@ -155,11 +170,11 @@ contract MinionFactory is CloneFactory {
     address[] public minionList; 
     mapping (address => AMinion) public minions;
     
-    event SummonMinion(address indexed minion, address indexed moloch, string name, string minionType);
+    event SummonMinion(address indexed minion, address indexed moloch, string details, string minionType);
     
     struct AMinion {
         address moloch;
-        string name; 
+        string details; 
     }
     
     
@@ -167,15 +182,15 @@ contract MinionFactory is CloneFactory {
         template = _template;
     }
     
-    function summonMinion(address moloch, string memory name) external returns (address) {
+    function summonMinion(address moloch, string memory details) external returns (address) {
         Minion minion = Minion(createClone(template));
         
         minion.init(moloch);
         string memory minionType = "vanilla minion";
         
-        minions[address(minion)] = AMinion(moloch, name);
+        minions[address(minion)] = AMinion(moloch, details);
         minionList.push(address(minion));
-        emit SummonMinion(address(minion), moloch, name, minionType);
+        emit SummonMinion(address(minion), moloch, details, minionType);
         
         return(address(minion));
         

--- a/MinionFactory.sol
+++ b/MinionFactory.sol
@@ -66,14 +66,18 @@ contract Minion {
         emit DoWithdraw(token, amount);
     }
     
-    function crossWithdraw(address target, address token, uint256 amount) external {
+    function crossWithdraw(address target, address token, uint256 amount, bool transfer) external {
         // @Dev - Target needs to have a withdrawBalance functions
-        bool whitelisted = moloch.tokenWhitelist(token);
-        require(whitelisted, "not a whitelisted token");
+  
         IMOLOCH(target).withdrawBalance(token, amount); 
         
         // Transfers token into DAO. 
-        IERC20(token).transfer(address(moloch), amount);
+        if(transfer) {
+            bool whitelisted = moloch.tokenWhitelist(token);
+            require(whitelisted, "not a whitelisted token");
+            require(IERC20(token).transfer(address(moloch), amount), "token transfer failed");
+        }
+        
         emit CrossWithdraw(target, token, amount);
     }
     

--- a/README.md
+++ b/README.md
@@ -16,4 +16,8 @@ Once your minion proposal has passed in the DAO you can call the executeAction f
 
 The doWithdraw function allows the minion to collect any funds waiting for the minion in its parent DAO. The doWithdraw function takes the token and amount as its arguments. 
 
-Other feature of the vanilla minion is the ability to withdraw funds directly one DAO into another (or the minion) using crossWithdraw. This function means that you can either draw funds from any Moloch into the minion (when transfer is set to false) or directly into the parent moloch (when transfer is set to true). The crossWithdraw function just takes a target address, a token address, an amount, and a true / false on that transfer option mentioned above. The crossWithdraw can only pull tokens directly into its parent DAO if the tokens have already been whitelisted.  
+Other features of the vanilla minion are the ability to withdraw funds and cancel proposals. 
+
+The crossWithdraw function means that you can either draw funds from any Moloch into the minion (when transfer is set to false) or directly into the parent moloch (when transfer is set to true). The crossWithdraw function just takes a target address, a token address, an amount, and a true / false on that transfer option mentioned above. The crossWithdraw can only pull tokens directly into its parent DAO if the tokens have already been whitelisted. 
+
+The cancelProposal function allows an proposer to cancel the proposal they submitted. This function just takes the proposalId of the proposal they submitted. The cancelProposal function must be called prior to the proposal being sponsored in the parent moloch. 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # MinionSummoner
 Summon All the Minions
+
+Summon a minion for your DAO, give it a name, just 'cause this is a vanilla minion (the OG) doesn't mean it doesn't deserve some spice. 
+
+Minion is meant for submitting proposals to DAOs for arbitrary contract calls (i.e. minion proposals allow the DAO to submit proposals that will allow it to interact with other smart contracts). The way to use a minion is to submit the proposal with all the normal fields plus the byte data you want to send to the other contract's function. One way to get this byte data is by pretending to interact with the target function using MetaMask and then clicking on the data tab and copying and pasting the Hex data into the byte data field for a minion proposal--there are also other ways of getting the necessary byte data that are slightly more advanced. 
+
+Once your minion proposal has passed in the DAO you can call the executeAction function. The executeAction function just takes the proposalId to make the desired contract interaction happen. 
+
+The doWithdraw function allows the minion to collect any funds waiting for the minion in its parent DAO. The doWithdraw function takes the token and amount as its arguments. 
+
+Other feature of the vanilla minion is the ability to withdraw funds directly one DAO into another (or the minion) using crossWithdraw. This function means that you can either draw funds from any Moloch into the minion (when transfer is set to false) or directly into the parent moloch (when transfer is set to true). The crossWithdraw function just takes a target address, a token address, an amount, and a true / false on that transfer option mentioned above. The crossWithdraw can only pull tokens directly into its parent DAO if the tokens have already been whitelisted.  

--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ Other features of the vanilla minion are the ability to withdraw funds and cance
 The crossWithdraw function means that you can either draw funds from any Moloch into the minion (when transfer is set to false) or directly into the parent moloch (when transfer is set to true). The crossWithdraw function just takes a target address, a token address, an amount, and a true / false on that transfer option mentioned above. The crossWithdraw can only pull tokens directly into its parent DAO if the tokens have already been whitelisted. 
 
 The cancelProposal function allows an proposer to cancel the proposal they submitted. This function just takes the proposalId of the proposal they submitted. The cancelProposal function must be called prior to the proposal being sponsored in the parent moloch. 
+
+## Deployments
+
+xDAI - 0x9610389d548Ca0224aCaC40eB3241c5ED88D2479
+
+kovan - 0x80ec2dB292E7a6D1D5bECB80e6479b2bE048AC98
+
+rinkeby - 0x316eFCd421b0654B7aE8E806880D4AE88ecaE206

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # MinionSummoner
 Summon All the Minions
 
+## Summoning 
 Summon a minion for your DAO, give it a name, just 'cause this is a vanilla minion (the OG) doesn't mean it doesn't deserve some spice. 
+
+Summoning a minion is easy. The only arguments the summon function takes are the address of the moloch it will minion for (e.g. it's parent DAO) and a description, which can be a name or other description for this minion's purpose. The summon function emits a SummonMinion event where you can grab the new minion's address.
+
+Details of summoned minions can be looked up in the minions mapping, which will allow you to search by minion address and retrieve information about the minion's description and the Moloch it serves. 
+
+## Using your minion 
 
 Minion is meant for submitting proposals to DAOs for arbitrary contract calls (i.e. minion proposals allow the DAO to submit proposals that will allow it to interact with other smart contracts). The way to use a minion is to submit the proposal with all the normal fields plus the byte data you want to send to the other contract's function. One way to get this byte data is by pretending to interact with the target function using MetaMask and then clicking on the data tab and copying and pasting the Hex data into the byte data field for a minion proposal--there are also other ways of getting the necessary byte data that are slightly more advanced. 
 


### PR DESCRIPTION
Small update we talked about to the vanilla minion: 

-  Made type and name field separate, so ppl can name their minions 
-  Added a mapping and list around this, so you can better call minion info onChain too
-  Added a cross withdraw function that will let minion withdraw an amount of tokens from any contract that uses the withdrawBalance function according to the IMOLOCH interface